### PR TITLE
Fix file uploads in RStudio

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -33,7 +33,6 @@ proxy.on('proxyReq', function (proxyReq, req, res, options) {
   setAuthCookie(proxyReq);
   if (req.body) {
     let length = Buffer.byteLength(req.body);
-    proxyReq.setHeader('Content-Type', 'application/json');
     proxyReq.setHeader('Content-Length', length);
     proxyReq.write(req.body);
   }


### PR DESCRIPTION
* Pass through request content type, rather than set it to `application/json`, because this obviously breaks POST requests where the content type is not JSON