### PR TITLE
Silent SSO

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -28,6 +28,7 @@ config.auth0 = {
   clientSecret: process.env.AUTH0_CLIENT_SECRET,
   domain: process.env.AUTH0_DOMAIN,
   passReqToCallback: true,
+  prompt: 'none',
   scope: 'profile',
   sso_logout_url: '/v2/logout',
 };

--- a/app/index.js
+++ b/app/index.js
@@ -31,6 +31,13 @@ const strategy = new Auth0Strategy(
     return callback(null, profile._json);
   }),
 );
+// Original implementation in `passport-openidconnect` ignore options by
+// returning `{}`.
+//
+// `passport-auth0-openidconnect` is supposed to override it but it doesn't.
+//
+// See: https://github.com/siacomuzzi/passport-openidconnect/blob/master/lib/strategy.js#L338
+Auth0Strategy.prototype.authorizationParams = (options) => options;
 passport.use(strategy);
 
 passport.serializeUser((user, done) => {

--- a/app/routes.js
+++ b/app/routes.js
@@ -21,7 +21,9 @@ router.get('/login', (req, res, next) => {
       res.redirect(req.session.returnTo);
     }
   } else {
-    passport.authenticate('auth0-oidc')(req, res, next);
+    passport.authenticate(
+      'auth0-oidc', { prompt: req.query.prompt || config.auth0.prompt },
+    )(req, res, next);
   }
 });
 
@@ -34,7 +36,7 @@ router.get(['/logout', '/auth-sign-out'], (req, res) => {
 });
 
 router.get('/callback', [
-  passport.authenticate('auth0-oidc', { failureRedirect: '/login' }),
+  passport.authenticate('auth0-oidc', { failureRedirect: '/login?prompt=true' }),
   (req, res) => {
     res.redirect(req.session.returnTo || '/');
   },


### PR DESCRIPTION
### What
Don't ask for confirmation when user already logged in Auth0 SSO.

By passing `?prompt=none` in the `/authorize` request Auth0 will not
ask to confirm the identity when already logged in SSO.

The effect will be that the user will be transparently be logged in the
application (RStudio in this case).

### Notes
When `?prompt=none` is passed to `/authorize` but the user is *not*
logged in SSO the user will not be promped to login and therefore can't
be logged in. In this case the application redirects to `/login` again by
passing `?prompt=true` so that the user can login.

### See
- [Auth0 Silent SSO documentation](https://auth0.com/docs/api-auth/tutorials/silent-authentication)
- passport-openidconnect's [Strategy.authorizationParams() implementation](https://github.com/siacomuzzi/passport-openidconnect/blob/master/lib/strategy.js#L338)