### PR TITLE
Session expires after 8 hours (by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # analytics-platform-rstudio-auth-proxy
 RStudio auth proxy
+
+
+### Environment variables
+
+- `COOKIE_MAXAGE`, maximum age of session cookies in seconds.
+  Defaults to `3600` seconds (1 hours).
+  See [`Set-Cookie: MaxAge` documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)

--- a/app/config.js
+++ b/app/config.js
@@ -20,6 +20,10 @@ config.session = {
   resave: true,
   saveUninitialized: true,
   secret: process.env.COOKIE_SECRET || 'shh-its-a-secret',
+  cookie: {
+    // `COOKIE_MAXAGE` in seconds (defaults to 1 hour = 3,600,000 ms)
+    maxAge: (Number.parseInt(process.env.COOKIE_MAXAGE, 10) || 3600) * 1000,
+  },
 };
 
 config.auth0 = {


### PR DESCRIPTION
Can be configured by setting the `COOKIE_MAXAGE` environment variable to
the number of seconds after which cookie session will expire.