### PR TITLE
Revert "Bump passport-auth0-openidconnect from 0.1.1 to 0.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -142,9 +142,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -235,7 +235,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.2.0"
       }
     },
     "brace-expansion": {
@@ -364,9 +364,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -463,7 +463,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.2.0"
           }
         }
       }
@@ -1000,12 +1000,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
       }
     },
@@ -1130,14 +1130,14 @@
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "hoek": "4.2.0",
+        "sntp": "2.0.2"
       }
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "hosted-git-info": {
       "version": "2.6.0",
@@ -1173,7 +1173,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "sshpk": "1.13.1"
       }
     },
     "iconv-lite": {
@@ -1666,25 +1666,40 @@
       }
     },
     "passport-auth0-openidconnect": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/passport-auth0-openidconnect/-/passport-auth0-openidconnect-0.2.0.tgz",
-      "integrity": "sha1-Tm0PEllbAxa0atdqjyEct7PUh9w=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/passport-auth0-openidconnect/-/passport-auth0-openidconnect-0.1.1.tgz",
+      "integrity": "sha1-blXPy1joF2PkaJydomHVTzQ4GlY=",
       "requires": {
-        "passport-openidconnect": "0.0.2",
+        "passport-openidconnect": "https://github.com/siacomuzzi/passport-openidconnect/tarball/state_store",
         "pkginfo": "0.3.1",
-        "request": "2.85.0",
+        "request": "2.83.0",
         "xtend": "4.0.1"
       }
     },
     "passport-openidconnect": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/passport-openidconnect/-/passport-openidconnect-0.0.2.tgz",
-      "integrity": "sha1-5Ij4vbOGyan9OckdWrjIgBVugVM=",
+      "version": "https://github.com/siacomuzzi/passport-openidconnect/tarball/state_store",
+      "integrity": "sha1-PrUL7dilDEr7XMgjv9cNsLJdRuY=",
       "requires": {
         "oauth": "0.9.15",
-        "passport-strategy": "1.0.0",
-        "request": "2.85.0",
-        "webfinger": "0.4.2"
+        "passport": "0.3.2",
+        "pkginfo": "0.2.3",
+        "webfinger": "0.3.2"
+      },
+      "dependencies": {
+        "passport": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
+          "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
+          "requires": {
+            "passport-strategy": "1.0.0",
+            "pause": "0.0.1"
+          }
+        },
+        "pkginfo": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+          "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg="
+        }
       }
     },
     "passport-strategy": {
@@ -1902,17 +1917,17 @@
       "dev": true
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
+        "aws4": "1.6.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "1.0.5",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
+        "form-data": "2.3.1",
         "har-validator": "5.0.3",
         "hawk": "6.0.2",
         "http-signature": "1.2.0",
@@ -1925,7 +1940,7 @@
         "qs": "6.5.1",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.4",
+        "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.2.1"
       }
@@ -2117,11 +2132,11 @@
       }
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
+      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.2.0"
       }
     },
     "spdx-correct": {
@@ -2163,9 +2178,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -2282,9 +2297,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -2382,9 +2397,9 @@
       }
     },
     "webfinger": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/webfinger/-/webfinger-0.4.2.tgz",
-      "integrity": "sha1-NHem2XeZRhiWA5/P/GULc0aO520=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/webfinger/-/webfinger-0.3.2.tgz",
+      "integrity": "sha1-5gKg+iA0utwTq0TLr/3+Gum4my8=",
       "requires": {
         "step": "0.0.6",
         "xml2js": "0.1.14"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "http-proxy": "^1.17.0",
     "morgan": "^1.9.0",
     "passport": "^0.4.0",
-    "passport-auth0-openidconnect": "^0.2.0",
+    "passport-auth0-openidconnect": "^0.1.1",
     "serve-favicon": "^2.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts ministryofjustice/analytics-platform-rstudio-auth-proxy#19

Bump to `passport-auth0-openidconnect` version `0.2.0` doesn't seem to work as it should annoyingly: [passport-auth0-openidconnect Issue #5](https://github.com/auth0/passport-auth0-openidconnect/issues/5).

It's not clear why same upgrade it's working fine for [kibana-auth-proxy](https://github.com/ministryofjustice/analytics-platform-kibana-auth-proxy/pull/5).